### PR TITLE
APIdocument-3028 リンク切れ解消

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 # kintone-plugin-license
 
 See below.  
-https://cybozu.dev/ja/kintone/tips/best-practices/plugin-license-management/
+https://cybozu.dev/ja/kintone/tips/development/plugins/development-plugin/plugin-license-management/


### PR DESCRIPTION
READMEに掲載されていた github の URL について、リンク切れが発生していたので解消しました。